### PR TITLE
rebuild every Saturday and on request

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -6,10 +6,12 @@ on:
     paths: 
     - "Dockerfile"
     - ".github/workflows/publish_docker.yml"
+  schedule:
+    - cron: "24 2 * * 6" # Every Saturday morning 02:24
+  workflow_dispatch:
 
 jobs:
   build-and-publish:
-    if: github.event.pull_request.merged
     permissions:
       packages: write
     runs-on: ubuntu-latest
@@ -26,6 +28,16 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: PR Tag
+      if: github.event.pull_request.merged
+      run: |
+        echo "TAG=pr${{ github.event.number  }}" >> $GITHUB_ENV
+
+    - name: Date Tag
+      if: ${{ ! github.event.pull_request.merged }}
+      run: |
+        echo "TAG=$(date -I)" >> $GITHUB_ENV
+
     - name: Define Image Metadata
       id: meta
       uses: docker/metadata-action@v5
@@ -33,7 +45,7 @@ jobs:
         images: |
           ghcr.io/musicalninjas/pyo3-devcontainer
         tags: |
-          type=raw,value=pr${{ github.event.number  }}
+          type=raw,value=${{ env.TAG }}
           type=raw,value=latest
 
     - name: Login to ghcr.io


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the GitHub Actions workflow to include a scheduled rebuild of the Docker image every Saturday and allows manual triggering of the workflow. It also enhances the tagging mechanism for Docker images by introducing conditional tags based on the event type.

- **Enhancements**:
    - Introduced conditional tagging for Docker images based on whether the event is a merged pull request or not.
- **CI**:
    - Added a scheduled workflow to rebuild the Docker image every Saturday at 02:24.
    - Enabled manual triggering of the workflow using 'workflow_dispatch'.

<!-- Generated by sourcery-ai[bot]: end summary -->