### PR TITLE
Don't cache Docker builds

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -6,10 +6,12 @@ on:
     paths: 
     - "Dockerfile"
     - ".github/workflows/publish_docker.yml"
+  schedule:
+    - cron: "24 2 * * 6" # Every Saturday morning 02:24
+  workflow_dispatch:
 
 jobs:
   build-and-publish:
-    if: github.event.pull_request.merged
     permissions:
       packages: write
     runs-on: ubuntu-latest
@@ -26,6 +28,16 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: PR Tag
+      if: github.event.pull_request.merged
+      run: |
+        echo "TAG=pr${{ github.event.number  }}" >> $GITHUB_ENV
+
+    - name: Date Tag
+      if: ${{ ! github.event.pull_request.merged }}
+      run: |
+        echo "TAG=$(date -I)" >> $GITHUB_ENV
+
     - name: Define Image Metadata
       id: meta
       uses: docker/metadata-action@v5
@@ -33,7 +45,7 @@ jobs:
         images: |
           ghcr.io/musicalninjas/pyo3-devcontainer
         tags: |
-          type=raw,value=pr${{ github.event.number  }}
+          type=raw,value=${{ env.TAG }}
           type=raw,value=latest
 
     - name: Login to ghcr.io

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -61,7 +61,5 @@ jobs:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Updated the GitHub Actions workflow for publishing Docker images by removing Docker build caching, adding a scheduled run, and introducing conditional tagging based on whether the build is for a pull request or a regular build.

- **CI**:
    - Added a scheduled workflow to run every Saturday morning at 02:24.
    - Introduced a manual trigger for the workflow using 'workflow_dispatch'.
    - Added conditional tagging for pull requests and date-based tags for other builds.

<!-- Generated by sourcery-ai[bot]: end summary -->